### PR TITLE
wire, blockchain, server: Add BlockHash to LeafData

### DIFF
--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -403,6 +403,16 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	log.Infof("Catching up indexes from height %d to %d", lowestHeight,
 		bestHeight)
 
+	// For Utreexo proof indexes, we have to set the chain.
+	for _, indexer := range m.enabledIndexes {
+		switch idxType := indexer.(type) {
+		case *UtreexoProofIndex:
+			idxType.SetChain(chain)
+		case *FlatUtreexoProofIndex:
+			idxType.SetChain(chain)
+		}
+	}
+
 	// Needed for flushing the utreexo state in case of a sigint by the user.
 	defer func() {
 		for _, indexer := range m.enabledIndexes {

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -50,6 +50,9 @@ type UtreexoProofIndex struct {
 	db          database.DB
 	chainParams *chaincfg.Params
 
+	// chain is solely used to fetch the blockindex data.
+	chain *blockchain.BlockChain
+
 	// mtx protects concurrent access to utreexoView.
 	mtx *sync.RWMutex
 
@@ -123,8 +126,9 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 			block.Height())
 		return nil
 	}
+
 	_, outCount, inskip, outskip := util.DedupeBlock(block)
-	dels, err := blockchain.BlockToDelLeaves(stxos, block, inskip)
+	dels, err := blockchain.BlockToDelLeaves(stxos, idx.chain, block, inskip)
 	if err != nil {
 		return err
 	}
@@ -231,6 +235,11 @@ func (idx *UtreexoProofIndex) GenerateUData(dels []wire.LeafData, height int32) 
 	}
 
 	return ud, nil
+}
+
+// SetChain sets the given chain as the chain to be used for blockhash fetching.
+func (idx *UtreexoProofIndex) SetChain(chain *blockchain.BlockChain) {
+	idx.chain = chain
 }
 
 // NewUtreexoProofIndex returns a new instance of an indexer that is used to create a

--- a/wire/leaf_test.go
+++ b/wire/leaf_test.go
@@ -12,75 +12,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
-//func createRandHash(rnd *rand.Rand) (*chainhash.Hash, error) {
-//	hashVal, ok := quick.Value(reflect.TypeOf(chainhash.Hash{}), rnd)
-//	if !ok {
-//		err := fmt.Errorf("Failed to create stxo")
-//		return nil, err
-//	}
-//	h := chainhash.Hash(hashVal.Interface().(chainhash.Hash))
-//	return &h, nil
-//}
-//
-//func createRandOP(rnd *rand.Rand) (*wire.OutPoint, error) {
-//	//index := rand.Uint32()
-//	//txHash, err := createRandHash(rnd)
-//	//if err != nil {
-//	//	return nil, err
-//	//}
-//
-//	//op := wire.OutPoint{
-//	//	Hash:  *txHash,
-//	//	Index: index,
-//	//}
-//
-//	opVal, ok := quick.Value(reflect.TypeOf(wire.OutPoint{}), rnd)
-//	if !ok {
-//		err := fmt.Errorf("Failed to create stxo")
-//		return nil, err
-//	}
-//	op := wire.OutPoint(opVal.Interface().(wire.OutPoint))
-//
-//	fmt.Println(op.String())
-//
-//	return &op, nil
-//}
-//
-//func createRandLeafData() (*LeafData, error) {
-//	rnd := rand.New(rand.NewSource(time.Now().Unix()))
-//
-//	op, err := createRandOP(rnd)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	blockHash, err := createRandHash(rnd)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	ld := LeafData{
-//		OutPoint:  op,
-//		BlockHash: blockHash,
-//	}
-//
-//	fmt.Println(ld)
-//
-//	return &ld, nil
-//}
-//
-//func createRandStxo() (*blockchain.SpentTxOut, error) {
-//	stxoVal, ok := quick.Value(reflect.TypeOf(blockchain.SpentTxOut{}), rand)
-//	if !ok {
-//		err := fmt.Errorf("Failed to create stxo")
-//		t.Fatal(err)
-//	}
-//	stxo := blockchain.SpentTxOut(stxoVal.Interface().(blockchain.SpentTxOut))
-//	fmt.Println(stxo)
-//
-//	stxo := blockchain.SpentTxOut{}
-//}
-
 // newHashFromStr converts the passed big-endian hex string into a
 // chainhash.Hash.  It only differs from the one available in chainhash in that
 // it ignores the error since it will only (and must only) be called with
@@ -114,7 +45,7 @@ func TestLeafDataSerialize(t *testing.T) {
 		{
 			name: "Testnet3 tx 061bb0bf... from block 1600000",
 			ld: LeafData{
-				BlockHash: newHashFromStr("00000000000172ff8a4e14441512072bacaf8d38b995a3fcd2f8435efc61717d"),
+				BlockHash: *newHashFromStr("00000000000172ff8a4e14441512072bacaf8d38b995a3fcd2f8435efc61717d"),
 				OutPoint: OutPoint{
 					Hash:  *newHashFromStr("061bb0bf3a1b9df13773da06bf92920394887a9c2b8b8772ac06be4e077df5eb"),
 					Index: 10,
@@ -128,7 +59,7 @@ func TestLeafDataSerialize(t *testing.T) {
 		{
 			name: "Mainnet coinbase tx fa201b65... from block 573123",
 			ld: LeafData{
-				BlockHash: newHashFromStr("000000000000000000278eb9386b4e70b850a4ec21907af3a27f50330b7325aa"),
+				BlockHash: *newHashFromStr("000000000000000000278eb9386b4e70b850a4ec21907af3a27f50330b7325aa"),
 				OutPoint: OutPoint{
 					Hash:  *newHashFromStr("fa201b650eef761f5701afbb610e4a211b86985da4745aec3ac0f4b7a8e2c8d2"),
 					Index: 0,
@@ -150,6 +81,12 @@ func TestLeafDataSerialize(t *testing.T) {
 		// Deserialize
 		checkLeaf := NewLeafData()
 		checkLeaf.Deserialize(writer)
+
+		if !bytes.Equal(test.ld.BlockHash[:], checkLeaf.BlockHash[:]) {
+			t.Errorf("%s: LeafData BlockHash mismatch. expect %s, got %s",
+				test.name, test.ld.BlockHash.String(),
+				checkLeaf.BlockHash.String())
+		}
 
 		if !bytes.Equal(test.ld.OutPoint.Hash[:], checkLeaf.OutPoint.Hash[:]) {
 			t.Errorf("%s: LeafData outpoint hash mismatch. expect %s, got %s",
@@ -209,7 +146,7 @@ func TestLeafDataSerializeCompact(t *testing.T) {
 		{
 			name: "Testnet3 tx 061bb0bf... from block 1600000",
 			ld: LeafData{
-				BlockHash: newHashFromStr("00000000000172ff8a4e14441512072bacaf8d38b995a3fcd2f8435efc61717d"),
+				BlockHash: *newHashFromStr("00000000000172ff8a4e14441512072bacaf8d38b995a3fcd2f8435efc61717d"),
 				OutPoint: OutPoint{
 					Hash:  *newHashFromStr("061bb0bf3a1b9df13773da06bf92920394887a9c2b8b8772ac06be4e077df5eb"),
 					Index: 10,
@@ -223,7 +160,7 @@ func TestLeafDataSerializeCompact(t *testing.T) {
 		{
 			name: "Mainnet coinbase tx fa201b65... from block 573123",
 			ld: LeafData{
-				BlockHash: newHashFromStr("000000000000000000278eb9386b4e70b850a4ec21907af3a27f50330b7325aa"),
+				BlockHash: *newHashFromStr("000000000000000000278eb9386b4e70b850a4ec21907af3a27f50330b7325aa"),
 				OutPoint: OutPoint{
 					Hash:  *newHashFromStr("fa201b650eef761f5701afbb610e4a211b86985da4745aec3ac0f4b7a8e2c8d2"),
 					Index: 0,

--- a/wire/udata_test.go
+++ b/wire/udata_test.go
@@ -33,7 +33,7 @@ func getLeafDatas() []leafDatas {
 			height: 104773,
 			leavesPerBlock: []LeafData{
 				{
-					BlockHash: newHashFromStr("000000000002bc1ddaae8ef976adf1c36db878b5f0711ec58c92ec0e4724277b"),
+					BlockHash: *newHashFromStr("000000000002bc1ddaae8ef976adf1c36db878b5f0711ec58c92ec0e4724277b"),
 					OutPoint: OutPoint{
 						Hash:  *newHashFromStr("43263e398303de72f5b8f5dd690c88cd87c31ec7c73cc98a567a4b73521428ea"),
 						Index: 0,
@@ -44,7 +44,7 @@ func getLeafDatas() []leafDatas {
 					IsCoinBase: false,
 				},
 				{
-					BlockHash: newHashFromStr("0000000000021ecac6ea6e14d61821b3ddcb8f4563c796957394e4181c261b4d"),
+					BlockHash: *newHashFromStr("0000000000021ecac6ea6e14d61821b3ddcb8f4563c796957394e4181c261b4d"),
 					OutPoint: OutPoint{
 						Hash:  *newHashFromStr("76c131357f1efc87434b3de49f9cf2660acaad5f360205ba390cb8726c01c948"),
 						Index: 0,
@@ -63,7 +63,7 @@ func getLeafDatas() []leafDatas {
 			height: 383,
 			leavesPerBlock: []LeafData{
 				{
-					BlockHash: newHashFromStr("00000000ff41b51f43141f3fd198016cead8c92355f7064849c4507f9e8914f8"),
+					BlockHash: *newHashFromStr("00000000ff41b51f43141f3fd198016cead8c92355f7064849c4507f9e8914f8"),
 					OutPoint: OutPoint{
 						Hash:  *newHashFromStr("58102e32e848fbd68c29480de00d653a88a6de077c46d8f6c37488290f2b4d43"),
 						Index: 0,
@@ -74,7 +74,7 @@ func getLeafDatas() []leafDatas {
 					IsCoinBase: true,
 				},
 				{
-					BlockHash: newHashFromStr("000000004a0cd08dbda8e47cbab13205ba9ae2f3e4b157c6b2539446db44aae9"),
+					BlockHash: *newHashFromStr("000000004a0cd08dbda8e47cbab13205ba9ae2f3e4b157c6b2539446db44aae9"),
 					OutPoint: OutPoint{
 						Hash:  *newHashFromStr("013e22e413cdf3e80eca36c058f0a31ac00ebcfbf547fa6a5688b5626d1739e7"),
 						Index: 0,
@@ -85,7 +85,7 @@ func getLeafDatas() []leafDatas {
 					IsCoinBase: true,
 				},
 				{
-					BlockHash: newHashFromStr("000000001a4c2c64beded987790ab0c00675b4bc467cd3574ad455b1397c967c"),
+					BlockHash: *newHashFromStr("000000001a4c2c64beded987790ab0c00675b4bc467cd3574ad455b1397c967c"),
 					OutPoint: OutPoint{
 						Hash:  *newHashFromStr("7e621eeb02874ab039a8566fd36f4591e65eca65313875221842c53de6907d6c"),
 						Index: 0,
@@ -96,7 +96,7 @@ func getLeafDatas() []leafDatas {
 					IsCoinBase: false,
 				},
 				{
-					BlockHash: newHashFromStr("0000000092907b867c2871a75a70de6d5e39c697eac57555a3896c19321c75b8"),
+					BlockHash: *newHashFromStr("0000000092907b867c2871a75a70de6d5e39c697eac57555a3896c19321c75b8"),
 					OutPoint: OutPoint{
 						Hash:  *newHashFromStr("6a2ea57b544fce1e36eafec6543486e3d49f66295ddc11f3ec2276295bf8eeaa"),
 						Index: 0,
@@ -343,12 +343,12 @@ func TestGenerateUData(t *testing.T) {
 		}
 		ld := leafVal.Interface().(LeafData)
 
-		outPointVal, ok := quick.Value(reflect.TypeOf(OutPoint{}), rand)
+		blockHashVal, ok := quick.Value(reflect.TypeOf(chainhash.Hash{}), rand)
 		if !ok {
 			t.Fatal("Could not create OutPoint")
 		}
-		op := outPointVal.Interface().(OutPoint)
-		ld.OutPoint = op
+		bh := blockHashVal.Interface().(chainhash.Hash)
+		ld.BlockHash = bh
 		leafDatas[i] = ld
 	}
 


### PR DESCRIPTION
We now commit the blockhash of the block the UTXO was created in.  This
eliminates collision attacks (section 5.6 of the utreexo paper
eprint.iacr.org/2019/611.pdf) as the attacker now has to mine valid
Bitcoin blocks to be able to collide the leaves.