### PR TITLE
indexers/flatfile: Fix restart bug

### DIFF
--- a/blockchain/indexers/flatfile_test.go
+++ b/blockchain/indexers/flatfile_test.go
@@ -168,10 +168,10 @@ func TestRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i, offset := range expectOffsets {
-		if offset != expectOffsets[i] {
+	for i, expectOffset := range expectOffsets {
+		if expectOffset != newff.offsets[i] {
 			err := fmt.Errorf("TestRestart Err. Expect offset at i of %d "+
-				"to be %d, got %d", i, expectOffsets[i], offset)
+				"to be %d, got %d", i, expectOffset, newff.offsets[i])
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
On restarts, the offsets loaded to memory would be incorrect.  Fixes the
test and the code to correct this issue.