### PR TITLE
Use compact UData serialization for MsgBlock and MsgTx

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1177,7 +1177,7 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 			if b.utreexoView != nil {
 				// Check that the block txOuts are valid by checking the utreexo proof and
 				// extra data.
-				err := b.utreexoView.Modify(block)
+				err := b.utreexoView.Modify(block, b.bestChain)
 				if err != nil {
 					return false, err
 				}

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -145,8 +145,8 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 		return err
 	}
 
-	bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSize()))
-	err = ud.Serialize(bytesBuf)
+	bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSizeCompact()))
+	err = ud.SerializeCompact(bytesBuf)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoProof(height int32) (*wire.UData, 
 	r := bytes.NewReader(proofBytes)
 
 	ud := new(wire.UData)
-	err = ud.Deserialize(r)
+	err = ud.DeserializeCompact(r)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -212,7 +212,7 @@ func (idx *UtreexoProofIndex) FetchUtreexoProof(hash *chainhash.Hash) (*wire.UDa
 		}
 		r := bytes.NewReader(proofBytes)
 
-		err = ud.Deserialize(r)
+		err = ud.DeserializeCompact(r)
 		if err != nil {
 			return err
 		}
@@ -285,10 +285,10 @@ func DropUtreexoProofIndex(db database.DB, dataDir string, interrupt <-chan stru
 // TODO Use the compact serialization.
 func dbStoreUtreexoProof(dbTx database.Tx, hash *chainhash.Hash, ud *wire.UData) error {
 	// Pre-allocated the needed buffer.
-	udSize := ud.SerializeSize()
+	udSize := ud.SerializeSizeCompact()
 	buf := bytes.NewBuffer(make([]byte, 0, udSize))
 
-	err := ud.Serialize(buf)
+	err := ud.SerializeCompact(buf)
 	if err != nil {
 		return err
 	}

--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The btcsuite developers
+// Copyright (c) 2021 The utreexo developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -23,7 +23,7 @@ type UtreexoViewpoint struct {
 // Modify takes an ublock and adds the utxos and deletes the stxos from the utreexo state.
 //
 // This function is NOT safe for concurrent access.
-func (uview *UtreexoViewpoint) Modify(block *btcutil.Block) error {
+func (uview *UtreexoViewpoint) Modify(block *btcutil.Block, bestChain *chainView) error {
 	// Check that UData field isn't nil before doing anything else.
 	if block.MsgBlock().UData == nil {
 		return fmt.Errorf("UtreexoViewpoint.Modify(): block.MsgBlock().UData is nil. " +
@@ -33,21 +33,25 @@ func (uview *UtreexoViewpoint) Modify(block *btcutil.Block) error {
 
 	// outskip is all the txOuts that are referenced by a txIn in the same block
 	// outCount is the count of all outskips.
-	_, outCount, _, outskip := util.DedupeBlock(block)
+	_, outCount, inskip, outskip := util.DedupeBlock(block)
 
-	// grab the "nl" (numLeaves) which is number of all the utxos currently in the
-	// utreexo accumulator. h is the height of the utreexo accumulator
-	nl, h := uview.accumulator.ReconstructStats()
-	err := ProofSanity(block, nl, h)
-	if err != nil {
-		return err
+	// Make slice of hashes from the LeafDatas. These are the hash commitments
+	// to be proven.
+	var delHashes []accumulator.Hash
+	if len(ud.LeafDatas) > 0 {
+		var err error
+		delHashes, err = generateCommitments(ud, block, bestChain, inskip)
+		if err != nil {
+			return err
+		}
 	}
 
-	// make slice of hashes from leafdata. These are the hash commitments
-	// to be proven.
-	delHashes := make([]accumulator.Hash, len(ud.LeafDatas))
-	for i := range ud.LeafDatas {
-		delHashes[i] = ud.LeafDatas[i].LeafHash()
+	// Grab the outpoints that need their existence proven and check that
+	// the udata matches up.
+	OPsToProve := util.BlockToDelOPs(block)
+	err := ProofSanity(ud, OPsToProve, block.Height())
+	if err != nil {
+		return err
 	}
 
 	// IngestBatchProof first checks that the utreexo proofs are valid. If it is valid,
@@ -83,37 +87,99 @@ func (uview *UtreexoViewpoint) Modify(block *btcutil.Block) error {
 	return nil
 }
 
-// ProofSanity checks the consistency of a UBlock.  Does the proof prove
-// all the inputs in the block?
-func ProofSanity(block *btcutil.Block, nl uint64, h uint8) error {
-	// get the outpoints that need proof
-	proveOPs := util.BlockToDelOPs(block)
-
-	ud := block.MsgBlock().UData
-	// ensure that all outpoints are provided in the extradata
-	if len(proveOPs) != len(ud.LeafDatas) {
-		err := fmt.Errorf("height %d %d outpoints need proofs but only %d proven\n",
-			ud.Height, len(proveOPs), len(ud.LeafDatas))
+// ProofSanity checks that the UData that was given proves the same outPoints that
+// is included in the corresponding block.
+func ProofSanity(ud *wire.UData, outPoints []wire.OutPoint, blockHeight int32) error {
+	if ud.Height != blockHeight {
+		err := fmt.Errorf("ProofSanity error: height mismatch. Udata height %d, block height %d",
+			ud.Height, blockHeight)
 		return err
 	}
 
+	// Check that the length is the same.
+	if len(outPoints) != len(ud.LeafDatas) {
+		err := fmt.Errorf("ProofSanity error at height %d. %d outpoints need proofs but %d proven\n",
+			ud.Height, len(outPoints), len(ud.LeafDatas))
+		return err
+	}
+
+	// Check that all the outpoints match up.
 	for i := range ud.LeafDatas {
-		if proveOPs[i].Hash != ud.LeafDatas[i].OutPoint.Hash ||
-			proveOPs[i].Index != ud.LeafDatas[i].OutPoint.Index {
-			err := fmt.Errorf("block/utxoData mismatch %s v %s\n",
-				proveOPs[i].String(), ud.LeafDatas[i].OutPoint.String())
+		if outPoints[i].Hash != ud.LeafDatas[i].OutPoint.Hash ||
+			outPoints[i].Index != ud.LeafDatas[i].OutPoint.Index {
+			err := fmt.Errorf("ProofSanity err: OutPoint mismatch. Expect %s, got %s\n",
+				outPoints[i].String(), ud.LeafDatas[i].OutPoint.String())
 			return err
 		}
 	}
 
-	// make sure the udata is consistent, with the same number of leafDatas
-	// as targets in the accumulator batch proof
+	// Final check.  The length of the targets should be the same as the leafdata
+	// as targets represent the positions of each of the leafdata hash in the
+	// accumulator.
 	if len(ud.AccProof.Targets) != len(ud.LeafDatas) {
-		fmt.Printf("Verify failed: %d targets but %d leafdatas\n",
+		return fmt.Errorf("ProofSanity err: %d targets but %d leafdatas\n",
 			len(ud.AccProof.Targets), len(ud.LeafDatas))
 	}
 
 	return nil
+}
+
+// generateCommitments adds in missing information to the passed in compact UData and
+// hashes it to recreate the hashes that were commited into the accumulator.  This
+// function also fills in the missing outpoint and blockhash information to the compact
+// UData, making it full.
+//
+// This function is safe for concurrent access.
+func generateCommitments(ud *wire.UData, block *btcutil.Block, chainView *chainView,
+	inskip []uint32) ([]accumulator.Hash, error) {
+	if chainView == nil {
+		return nil, fmt.Errorf("Passed in chainView is nil. Cannot make compact udata to full")
+	}
+
+	// blockInIdx is used to get the indexes of the skips.  ldIdx is used
+	// as a separate idx for the LeafDatas.  We need both of them because
+	// LeafDatas have already been deduped while the transactions are not.
+	var blockInIdx, ldIdx uint32
+	delHashes := make([]accumulator.Hash, 0, len(ud.LeafDatas))
+	for idx, tx := range block.Transactions() {
+		if idx == 0 {
+			// coinbase can have many inputs
+			blockInIdx += uint32(len(tx.MsgTx().TxIn))
+			continue
+		}
+		for _, txIn := range tx.MsgTx().TxIn {
+			// Skip txos on the skip list
+			if len(inskip) > 0 && inskip[0] == blockInIdx {
+				inskip = inskip[1:]
+				blockInIdx++
+				continue
+			}
+
+			ld := &ud.LeafDatas[ldIdx]
+
+			// Get BlockHash.
+			blockNode := chainView.NodeByHeight(ld.Height)
+			if blockNode == nil {
+				return nil, fmt.Errorf("Couldn't find blockNode for height %d",
+					ld.Height)
+			}
+			ld.BlockHash = blockNode.hash
+
+			// Get OutPoint.
+			op := wire.OutPoint{
+				Hash:  txIn.PreviousOutPoint.Hash,
+				Index: txIn.PreviousOutPoint.Index,
+			}
+			ld.OutPoint = op
+
+			delHashes = append(delHashes, ld.LeafHash())
+
+			blockInIdx++
+			ldIdx++
+		}
+	}
+
+	return delHashes, nil
 }
 
 // BlockToAdds turns all the new utxos in a msgblock into leafTxos

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1032,7 +1032,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	if b.utreexoView != nil {
 		// Check that the block txOuts are valid by checking the utreexo proof and
 		// extra data.
-		err := b.utreexoView.Modify(block)
+		err := b.utreexoView.Modify(block, b.bestChain)
 		if err != nil {
 			return err
 		}

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -110,7 +110,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 
 	if enc&UtreexoEncoding == UtreexoEncoding {
 		msg.UData = new(UData)
-		err = msg.UData.Deserialize(r)
+		err = msg.UData.DeserializeCompact(r)
 		if err != nil {
 			return err
 		}
@@ -221,7 +221,7 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) er
 			str := "utreexo encoding specified but MsgBlock.UData field is nil"
 			return messageError("MsgBlock.BtcEncode", str)
 		}
-		err = msg.UData.Serialize(w)
+		err = msg.UData.SerializeCompact(w)
 		if err != nil {
 			return err
 		}

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -677,7 +677,7 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 
 	if enc&UtreexoEncoding == UtreexoEncoding {
 		msg.UData = new(UData)
-		err = msg.UData.Deserialize(r)
+		err = msg.UData.DeserializeCompact(r)
 		if err != nil {
 			return err
 		}
@@ -786,7 +786,7 @@ func (msg *MsgTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error
 		// AccProof can be nil for transactions that are included in
 		// a block.
 		if msg.UData != nil {
-			err = msg.UData.Serialize(w)
+			err = msg.UData.SerializeCompact(w)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
We switch to using compact UData serialization for both the block and tx. This same serialization is used for storing proofs to the disk and results in massive savings for disk and bandwidth usage.