### PR TITLE
wire: New leaf compact serialization format

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -139,14 +139,14 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 	adds := blockchain.BlockToAddLeaves(block, nil, outskip, outCount)
 
 	idx.mtx.RLock()
-	ud, err := wire.GenerateUData(dels, idx.utreexoState.state, block.Height())
+	ud, err := wire.GenerateUData(dels, idx.utreexoState.state)
 	idx.mtx.RUnlock()
 	if err != nil {
 		return err
 	}
 
-	bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSizeCompact()))
-	err = ud.SerializeCompact(bytesBuf)
+	bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSizeCompact(udataSerializeBool)))
+	err = ud.SerializeCompact(bytesBuf, udataSerializeBool)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoProof(height int32) (*wire.UData, 
 	r := bytes.NewReader(proofBytes)
 
 	ud := new(wire.UData)
-	err = ud.DeserializeCompact(r)
+	err = ud.DeserializeCompact(r, udataSerializeBool, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -260,9 +260,9 @@ func (idx *FlatUtreexoProofIndex) fetchUndoBlock(height int32) (*accumulator.Und
 // GenerateUData generates utreexo data for the dels passed in.  Height passed in
 // should either be of block height of where the deletions are happening or just
 // the lastest block height for mempool tx proof generation.
-func (idx *FlatUtreexoProofIndex) GenerateUData(dels []wire.LeafData, height int32) (*wire.UData, error) {
+func (idx *FlatUtreexoProofIndex) GenerateUData(dels []wire.LeafData) (*wire.UData, error) {
 	idx.mtx.RLock()
-	ud, err := wire.GenerateUData(dels, idx.utreexoState.state, height)
+	ud, err := wire.GenerateUData(dels, idx.utreexoState.state)
 	idx.mtx.RUnlock()
 	if err != nil {
 		return nil, err

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -22,6 +22,10 @@ const (
 	defaultUtreexoCowDirName   = "cowstate"
 	defaultUtreexoCowFileName  = "CURRENT"
 	defaultCowMaxCache         = 1000
+
+	// udataSerializeBool defines the argument that should be passed to the
+	// serialize and deserialize functions for udata.
+	udataSerializeBool = false
 )
 
 // UtreexoConfig is a descriptor which specifies the Utreexo state instance configuration.

--- a/wire/leaf.go
+++ b/wire/leaf.go
@@ -5,7 +5,9 @@
 package wire
 
 import (
+	"bytes"
 	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
 	"io"
 
@@ -57,10 +59,10 @@ func (l *LeafData) LeafHash() [32]byte {
 
 // ToString turns a LeafData into a string for logging.
 func (l *LeafData) ToString() (s string) {
-	s += fmt.Sprintf("BlockHash:%x,", l.BlockHash)
+	s += fmt.Sprintf("BlockHash:%s,", hex.EncodeToString(l.BlockHash[:]))
 	s += fmt.Sprintf("OutPoint:%s,", l.OutPoint.String())
 	s += fmt.Sprintf("Amount:%d,", l.Amount)
-	s += fmt.Sprintf("PkScript:%x,", l.PkScript)
+	s += fmt.Sprintf("PkScript:%s,", hex.EncodeToString(l.PkScript))
 	s += fmt.Sprintf("BlockHeight:%d,", l.Height)
 	s += fmt.Sprintf("IsCoinBase:%v,", l.IsCoinBase)
 	s += fmt.Sprintf("LeafHash:%x,", l.LeafHash())
@@ -68,18 +70,26 @@ func (l *LeafData) ToString() (s string) {
 	return
 }
 
+// IsUnconfirmed returns whether the leaf data in question corresponds to an
+// unconfirmed transaction.
+func (l *LeafData) IsUnconfirmed() bool {
+	return l.Height == -1
+}
+
+// SetUnconfirmed sets the leaf data as unconfirmed.
+func (l *LeafData) SetUnconfirmed() {
+	l.Height = -1
+}
+
 // -----------------------------------------------------------------------------
 // LeafData serialization includes all the data needed for generating the hash
 // commitment of the LeafData.
 //
 // The serialized format is:
-// [<block hash><outpoint><stxo>]
+// [<block hash><outpoint><header code><amount><pkscript len><pkscript>]
 //
 // The outpoint serialized format is:
 // [<tx hash><index>]
-//
-// The stxo serialized format is:
-// [<header code><amount><pkscript len><pkscript>]
 //
 // The serialized header code format is:
 //   bit 0 - containing transaction is a coinbase
@@ -203,7 +213,10 @@ func (l *LeafData) Deserialize(r io.Reader) error {
 // commitment for the LeafData, there data left out from the compact serialization
 // is still needed and must be fetched from the Bitcoin block.
 //
-// The serialized format is:
+// Also note that the serialization differs for whether this leaf data is for a
+// block or for a transaction.
+//
+// The serialized format for a block is:
 // [<header code><amount><pkscript len><pkscript>]
 //
 // The serialized header code format is:
@@ -222,20 +235,61 @@ func (l *LeafData) Deserialize(r io.Reader) error {
 // pkscript length    VLQ        variable
 // pkscript           []byte     variable
 //
+// The serialized format for a transaction is:
+// [<unconfirmed marker><header code><amount><pkscript len><pkscript>]
+//
+// All other fields with the exception of 'unconfirmed marker' is the same as
+// the serialization for a block.  The unconfirmed marker is represented in
+// the struct as height = -1.
+//
+// Field               Type       Size
+// unconfirmed marker  byte       1
+// header code         int32      4
+// amount              int64      8
+// pkscript length     VLQ        variable
+// pkscript            []byte     variable
+//
 // -----------------------------------------------------------------------------
 
 // SerializeSizeCompact returns the number of bytes it would take to serialize the
 // LeafData in the compact serialization format.
-func (l *LeafData) SerializeSizeCompact() int {
-	// header code 4 bytes + amount 8 bytes
-	size := 12
-
-	// Add pkscript size.
-	return size + VarIntSerializeSize(uint64(len(l.PkScript))) + len(l.PkScript)
+func (l *LeafData) SerializeSizeCompact(isForTx bool) int {
+	if isForTx {
+		if l.IsUnconfirmed() {
+			// If the leaf data corresponds to an unconfirmed tx, we only
+			// send a byte.
+			return 1
+		} else {
+			// header code 4 bytes + amount 8 bytes + unconfirmed marker + pkscript.
+			return 13 + VarIntSerializeSize(uint64(len(l.PkScript))) + len(l.PkScript)
+		}
+	}
+	// header code 4 bytes + amount 8 bytes + pkscript.
+	return 12 + VarIntSerializeSize(uint64(len(l.PkScript))) + len(l.PkScript)
 }
 
 // SerializeCompact encodes the LeafData to w using the compact leaf data serialization format.
-func (l *LeafData) SerializeCompact(w io.Writer) error {
+func (l *LeafData) SerializeCompact(w io.Writer, isForTx bool) error {
+	if isForTx {
+		// If the tx is unconfirmed, write the unconfirmed marker and
+		// return immediately.
+		if l.IsUnconfirmed() {
+			_, err := w.Write([]byte{0x1})
+			if err != nil {
+				return err
+			}
+
+			// Return if unconfirmed.
+			return nil
+		}
+
+		// Write 0 to mark that this transaction is confirmed.
+		_, err := w.Write([]byte{0x0})
+		if err != nil {
+			return err
+		}
+	}
+
 	bs := newSerializer()
 	defer bs.free()
 
@@ -261,7 +315,25 @@ func (l *LeafData) SerializeCompact(w io.Writer) error {
 }
 
 // DeserializeCompact encodes the LeafData to w using the compact leaf serialization format.
-func (l *LeafData) DeserializeCompact(r io.Reader) error {
+func (l *LeafData) DeserializeCompact(r io.Reader, isForTx bool) error {
+	if isForTx {
+		// Read unconfirmed marker.
+		unconfirmed := make([]byte, 1)
+		_, err := io.ReadFull(r, unconfirmed)
+		if err != nil {
+			return err
+		}
+
+		// 1 means that the LeafData corresponds to an uncomfirmed tx.
+		// Set IsUnconfirmed as true and return.
+		if bytes.Equal(unconfirmed, []byte{0x1}) {
+			l.SetUnconfirmed()
+
+			// Return immediately here if the tx is unconfirmed.
+			return nil
+		}
+	}
+
 	bs := newSerializer()
 	defer bs.free()
 

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -110,7 +110,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 
 	if enc&UtreexoEncoding == UtreexoEncoding {
 		msg.UData = new(UData)
-		err = msg.UData.DeserializeCompact(r)
+		err = msg.UData.DeserializeCompact(r, false, 0)
 		if err != nil {
 			return err
 		}
@@ -221,7 +221,7 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) er
 			str := "utreexo encoding specified but MsgBlock.UData field is nil"
 			return messageError("MsgBlock.BtcEncode", str)
 		}
-		err = msg.UData.SerializeCompact(w)
+		err = msg.UData.SerializeCompact(w, false)
 		if err != nil {
 			return err
 		}

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -677,7 +677,7 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 
 	if enc&UtreexoEncoding == UtreexoEncoding {
 		msg.UData = new(UData)
-		err = msg.UData.DeserializeCompact(r)
+		err = msg.UData.DeserializeCompact(r, true, len(msg.TxIn))
 		if err != nil {
 			return err
 		}
@@ -786,7 +786,7 @@ func (msg *MsgTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error
 		// AccProof can be nil for transactions that are included in
 		// a block.
 		if msg.UData != nil {
-			err = msg.UData.SerializeCompact(w)
+			err = msg.UData.SerializeCompact(w, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
With leaf compact serialization, the outpoint is left out.  Because of
this, the reader is responsible for filling in that information.
However, with tx messages, inputs may be unconfirmed, resulting in no
leaf data for such inputs.

This caused a problem where you might have 3 inputs but only 2 leaf
datas.  Since the compact leaf data leaves out the outpoint, you don't
know which inputs correspond to which leaf data.

The new serialization method fixes this by forcing the sender to always
send the equal amount of leaf datas for each of the inputs.  If an input
is unconfirmed, you simply send a 0x01, and the reader recognizes this
as leaf data corresponding to an unconfirmed input.

Note that only tx messages are effected and block messages stay the same.

Lastly, the unneccesary block height information from UData is removed.