### PR TITLE
wire/batchproof: Add batchproof.go

### DIFF
--- a/wire/batchproof.go
+++ b/wire/batchproof.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"io"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/mit-dci/utreexo/accumulator"
+)
+
+// BatchProofSerializeSize returns the number of bytes it would tkae to serialize
+// a BatchProof.
+func BatchProofSerializeSize(bp *accumulator.BatchProof) int {
+	size := VarIntSerializeSize(uint64(len(bp.Targets)))
+	size += VarIntSerializeSize(uint64(len(bp.Proof)))
+	size += chainhash.HashSize * len(bp.Proof)
+	return size + (8 * len(bp.Targets))
+}
+
+// -----------------------------------------------------------------------------
+// BatchProof serialization defines how the utreexo accumulator proof will be
+// serialized both for i/o.
+//
+// Note that this serialization format differs from the one from
+// github.com/mit-dci/utreexo/accumulator as this serialization method uses
+// varints and the one in that package does not.  They are not compatible and
+// should not be used together.  The serialization method here is more compact
+// and thus is better for wire and disk storage.
+//
+// The serialized format is:
+// [<target count><targets><proof count><proofs>]
+//
+// All together, the serialization looks like so:
+// Field          Type       Size
+// target count   varint     1-8 bytes
+// targets        []uint64   variable
+// hash count     varint     1-8 bytes
+// hashes         []32 byte  variable
+//
+// -----------------------------------------------------------------------------
+
+// BatchProofSerialize encodes the BatchProof to w using the BatchProof
+// serialization format.
+func BatchProofSerialize(w io.Writer, bp *accumulator.BatchProof) error {
+	bs := newSerializer()
+	defer bs.free()
+
+	err := WriteVarInt(w, 0, uint64(len(bp.Targets)))
+	if err != nil {
+		return err
+	}
+
+	for _, t := range bp.Targets {
+		err = bs.PutUint64(w, littleEndian, t)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = WriteVarInt(w, 0, uint64(len(bp.Proof)))
+	if err != nil {
+		return err
+	}
+
+	// then the rest is just hashes
+	for _, h := range bp.Proof {
+		_, err = w.Write(h[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BatchProofSerialize decodes the BatchProof to r using the BatchProof
+// serialization format.
+func BatchProofDeserialize(r io.Reader) (*accumulator.BatchProof, error) {
+	targetCount, err := ReadVarInt(r, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	bs := newSerializer()
+	defer bs.free()
+
+	targets := make([]uint64, targetCount)
+	for i := range targets {
+		target, err := bs.Uint64(r, littleEndian)
+		if err != nil {
+			return nil, err
+		}
+
+		targets[i] = target
+	}
+
+	proofCount, err := ReadVarInt(r, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	proofs := make([]accumulator.Hash, proofCount)
+	for i := range proofs {
+		_, err = io.ReadFull(r, proofs[i][:])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &accumulator.BatchProof{Targets: targets, Proof: proofs}, nil
+}

--- a/wire/batchproof_test.go
+++ b/wire/batchproof_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/mit-dci/utreexo/accumulator"
+)
+
+func testLeavesToHashes() []accumulator.Hash {
+	hashes := make([]accumulator.Hash, 0, len(testLeaves))
+	for _, leaf := range testLeaves {
+		hashes = append(hashes, leaf.Hash)
+	}
+
+	return hashes
+}
+
+func makeBatchProof() (*accumulator.BatchProof, error) {
+	// Create forest and add testLeaves.
+	f := accumulator.NewForest(accumulator.RamForest, nil, "", 0)
+	_, err := f.Modify(testLeaves, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	leaves := testLeavesToHashes()
+
+	// Generate BatchProof, only prove one.
+	batchProof, err := f.ProveBatch(leaves[:1])
+	if err != nil {
+		return nil, err
+	}
+
+	return &batchProof, nil
+}
+
+func compareBatchProof(bp, newBP *accumulator.BatchProof) error {
+	if len(bp.Targets) != len(newBP.Targets) {
+		return fmt.Errorf("BatchProofs differ. Expect target length of %d, got %d",
+			len(bp.Targets), len(newBP.Targets))
+	}
+
+	if len(bp.Proof) != len(newBP.Proof) {
+		return fmt.Errorf("BatchProofs differ. Expect proof length of %d, got %d",
+			len(bp.Proof), len(newBP.Proof))
+	}
+
+	for i := range bp.Targets {
+		if bp.Targets[i] != newBP.Targets[i] {
+			return fmt.Errorf("Expected target of %d, got %d",
+				bp.Targets[i], newBP.Targets[i])
+		}
+	}
+
+	for i := range bp.Proof {
+		if bp.Proof[i] != newBP.Proof[i] {
+			return fmt.Errorf("Expected proof of %d, got %d",
+				bp.Proof[i], newBP.Proof[i])
+		}
+	}
+
+	return nil
+}
+
+func TestBatchProofSerializeSize(t *testing.T) {
+	t.Parallel()
+
+	bp, err := makeBatchProof()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1 byte target len + one 8 byte target +
+	// 1 byte proof len + three proofs that are each 32 bytes (total 96 bytes)
+	if BatchProofSerializeSize(bp) != 106 {
+		err := fmt.Errorf("expect size of %d but got %d",
+			106, BatchProofSerializeSize(bp))
+		t.Errorf(err.Error())
+	}
+}
+
+func TestSerializeBatchProof(t *testing.T) {
+	t.Parallel()
+
+	bp, err := makeBatchProof()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Serialize the batchproof.
+	var w bytes.Buffer
+	err = bp.Serialize(&w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedBytes := w.Bytes()
+
+	var newBP accumulator.BatchProof
+
+	// Deserialize the batchproof.
+	r := bytes.NewBuffer(serializedBytes)
+	err = newBP.Deserialize(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = compareBatchProof(bp, &newBP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var newW bytes.Buffer
+	newBP.Serialize(&newW)
+	newSerializedBytes := newW.Bytes()
+
+	if !bytes.Equal(newSerializedBytes, serializedBytes) {
+		err := fmt.Errorf("Serialized BatchProof not equal. Expect %s, got %s",
+			hex.EncodeToString(serializedBytes),
+			hex.EncodeToString(newSerializedBytes))
+		t.Fatal(err)
+	}
+}
+
+// Leaves made for testing purposes.
+var testLeaves = []accumulator.Leaf{
+	{
+		Hash:     sha512.Sum512_256([]byte{0}),
+		Remember: true,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{1}),
+		Remember: true,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{2}),
+		Remember: true,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{3}),
+		Remember: true,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{4}),
+		Remember: false,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{5}),
+		Remember: false,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{6}),
+		Remember: false,
+	},
+	{
+		Hash:     sha512.Sum512_256([]byte{7}),
+		Remember: true,
+	},
+}

--- a/wire/udata_test.go
+++ b/wire/udata_test.go
@@ -233,7 +233,7 @@ func TestUDataSerializeSize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ttlAndProofSize := (len(ud.TxoTTLs) * 4) + ud.AccProof.SerializeSize()
+		ttlAndProofSize := (len(ud.TxoTTLs) * 4) + BatchProofSerializeSize(&ud.AccProof)
 
 		// Test size.
 		size := 0


### PR DESCRIPTION
BatchProof serialization was defined in github.com/mit-dci/utreexo.
However, this BatchProof serialization did not use variable integers,
therefore making UData messages sent over the wire to be bigger.

Redefining the BatchProof serialization in github.com/mit-dci/utreexo is
tricky since there is no variable integer support in that repo.  We
couldn't import the wire package into the utreexo repo since that caused
a dependency cycle.

The solution I came to is to just define a separate function for
serialization in this repo and I think this is a good enough solution.