### PR TITLE
rpcserver: Add gettxtotals command

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -585,6 +585,15 @@ func NewGetNetTotalsCmd() *GetNetTotalsCmd {
 	return &GetNetTotalsCmd{}
 }
 
+// GetTxTotalsCmd defines the gettxtotals JSON-RPC command.
+type GetTxTotalsCmd struct{}
+
+// NewGetTxTotalsCmd returns a new instance which can be used to issue a
+// gettxtotals JSON-RPC command.
+func NewGetTxTotalsCmd() *GetTxTotalsCmd {
+	return &GetTxTotalsCmd{}
+}
+
 // GetNetworkHashPSCmd defines the getnetworkhashps JSON-RPC command.
 type GetNetworkHashPSCmd struct {
 	Blocks *int `jsonrpcdefault:"120"`
@@ -1095,6 +1104,7 @@ func init() {
 	MustRegisterCmd("getmininginfo", (*GetMiningInfoCmd)(nil), flags)
 	MustRegisterCmd("getnetworkinfo", (*GetNetworkInfoCmd)(nil), flags)
 	MustRegisterCmd("getnettotals", (*GetNetTotalsCmd)(nil), flags)
+	MustRegisterCmd("gettxtotals", (*GetTxTotalsCmd)(nil), flags)
 	MustRegisterCmd("getnetworkhashps", (*GetNetworkHashPSCmd)(nil), flags)
 	MustRegisterCmd("getnodeaddresses", (*GetNodeAddressesCmd)(nil), flags)
 	MustRegisterCmd("getpeerinfo", (*GetPeerInfoCmd)(nil), flags)

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -510,6 +510,15 @@ type GetNetTotalsResult struct {
 	TimeMillis     int64  `json:"timemillis"`
 }
 
+// GetTxTotalsResult models the data returned from the gettxtotals command.
+type GetTxTotalsResult struct {
+	TotalTxBytesRecv    uint64 `json:"totaltxbytesrecv"`
+	TotalTxBytesSent    uint64 `json:"totaltxbytessent"`
+	TotalProofBytesRecv uint64 `json:"totalproofbytesrecv"`
+	TotalProofBytesSent uint64 `json:"totalproofbytessent"`
+	TimeMillis          int64  `json:"timemillis"`
+}
+
 // ScriptSig models a signature script.  It is defined separately since it only
 // applies to non-coinbase.  Therefore the field in the Vin structure needs
 // to be a pointer.

--- a/rpcadapters.go
+++ b/rpcadapters.go
@@ -164,6 +164,16 @@ func (cm *rpcConnManager) NetTotals() (uint64, uint64) {
 	return cm.server.NetTotals()
 }
 
+// TxTotals returns the sum of all bytes received and sent across the network
+// for all peers for tx messages and the utreexo proof that would have been
+// needed to prove it.
+//
+// This function is safe for concurrent access and is part of the
+// rpcserverConnManager interface implementation.
+func (cm *rpcConnManager) TxTotals() (uint64, uint64, uint64, uint64) {
+	return cm.server.TxTotals()
+}
+
 // ConnectedPeers returns an array consisting of all connected peers.
 //
 // This function is safe for concurrent access and is part of the

--- a/rpcclient/net.go
+++ b/rpcclient/net.go
@@ -391,3 +391,40 @@ func (c *Client) GetNetTotalsAsync() FutureGetNetTotalsResult {
 func (c *Client) GetNetTotals() (*btcjson.GetNetTotalsResult, error) {
 	return c.GetNetTotalsAsync().Receive()
 }
+
+// FutureGetTxTotalsResult is a future promise to deliver the result of a
+// GetTxTotalsAsync RPC invocation (or an applicable error).
+type FutureGetTxTotalsResult chan *Response
+
+// Receive waits for the Response promised by the future and returns network
+// traffic statistics.
+func (r FutureGetTxTotalsResult) Receive() (*btcjson.GetTxTotalsResult, error) {
+	res, err := ReceiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal result as a getnettotals result object.
+	var totals btcjson.GetTxTotalsResult
+	err = json.Unmarshal(res, &totals)
+	if err != nil {
+		return nil, err
+	}
+
+	return &totals, nil
+}
+
+// GetTxTotalsAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See GetTxTotals for the blocking version and more details.
+func (c *Client) GetTxTotalsAsync() FutureGetTxTotalsResult {
+	cmd := btcjson.NewGetTxTotalsCmd()
+	return c.SendCmd(cmd)
+}
+
+// GetTxTotals returns network traffic statistics.
+func (c *Client) GetTxTotals() (*btcjson.GetTxTotalsResult, error) {
+	return c.GetTxTotalsAsync().Receive()
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -158,6 +158,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getmempoolinfo":         handleGetMempoolInfo,
 	"getmininginfo":          handleGetMiningInfo,
 	"getnettotals":           handleGetNetTotals,
+	"gettxtotals":            handleGetTxTotals,
 	"getnetworkhashps":       handleGetNetworkHashPS,
 	"getnodeaddresses":       handleGetNodeAddresses,
 	"getpeerinfo":            handleGetPeerInfo,
@@ -274,6 +275,7 @@ var rpcLimited = map[string]struct{}{
 	"getheaders":            {},
 	"getinfo":               {},
 	"getnettotals":          {},
+	"gettxtotals":           {},
 	"getnetworkhashps":      {},
 	"getrawmempool":         {},
 	"getrawtransaction":     {},
@@ -2388,6 +2390,19 @@ func handleGetNetTotals(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 		TotalBytesRecv: totalBytesRecv,
 		TotalBytesSent: totalBytesSent,
 		TimeMillis:     time.Now().UTC().UnixNano() / int64(time.Millisecond),
+	}
+	return reply, nil
+}
+
+// handleGetTxTotals implements the gettxtotals command.
+func handleGetTxTotals(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	txBytesRecv, txBytesSent, proofBytesRecv, proofBytesSent := s.cfg.ConnMgr.TxTotals()
+	reply := &btcjson.GetTxTotalsResult{
+		TotalTxBytesRecv:    txBytesRecv,
+		TotalTxBytesSent:    txBytesSent,
+		TotalProofBytesRecv: proofBytesRecv,
+		TotalProofBytesSent: proofBytesSent,
+		TimeMillis:          time.Now().UTC().UnixNano() / int64(time.Millisecond),
 	}
 	return reply, nil
 }
@@ -4529,6 +4544,10 @@ type rpcserverConnManager interface {
 	// NetTotals returns the sum of all bytes received and sent across the
 	// network for all peers.
 	NetTotals() (uint64, uint64)
+
+	// TxTotals returns the sum of all bytes received and sent across the
+	// network for all peers for tx messages.
+	TxTotals() (uint64, uint64, uint64, uint64)
 
 	// ConnectedPeers returns an array consisting of all connected peers.
 	ConnectedPeers() []rpcserverPeer

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -451,10 +451,20 @@ var helpDescsEnUS = map[string]string{
 	// GetNetTotalsCmd help.
 	"getnettotals--synopsis": "Returns a JSON object containing network traffic statistics.",
 
+	// GetTxTotalsCmd help.
+	"gettxtotals--synopsis": "Returns a JSON object containing network traffic statistics for tx messages.",
+
 	// GetNetTotalsResult help.
 	"getnettotalsresult-totalbytesrecv": "Total bytes received",
 	"getnettotalsresult-totalbytessent": "Total bytes sent",
 	"getnettotalsresult-timemillis":     "Number of milliseconds since 1 Jan 1970 GMT",
+
+	// GetTxTotalsResult help.
+	"gettxtotalsresult-totaltxbytesrecv":    "Total tx bytes received",
+	"gettxtotalsresult-totaltxbytessent":    "Total tx bytes sent",
+	"gettxtotalsresult-totalproofbytesrecv": "Total proof bytes received",
+	"gettxtotalsresult-totalproofbytessent": "Total proof bytes sent",
+	"gettxtotalsresult-timemillis":          "Number of milliseconds since 1 Jan 1970 GMT",
 
 	// GetNodeAddressesResult help.
 	"getnodeaddressesresult-time":     "Timestamp in seconds since epoch (Jan 1 1970 GMT) keeping track of when the node was last seen",
@@ -748,6 +758,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getmempoolinfo":         {(*btcjson.GetMempoolInfoResult)(nil)},
 	"getmininginfo":          {(*btcjson.GetMiningInfoResult)(nil)},
 	"getnettotals":           {(*btcjson.GetNetTotalsResult)(nil)},
+	"gettxtotals":            {(*btcjson.GetTxTotalsResult)(nil)},
 	"getnetworkhashps":       {(*int64)(nil)},
 	"getnodeaddresses":       {(*[]btcjson.GetNodeAddressesResult)(nil)},
 	"getpeerinfo":            {(*[]btcjson.GetPeerInfoResult)(nil)},


### PR DESCRIPTION
gettxtotals returns the total bytes sent and received for all peers for
just the tx messages.  It also calculates the size of the utreexo proof
that would have been needed to prove that tx.

The main functinality of this rpc call is to calculate how much the
utreexo proofs would increase the network traffic needed to run a
utreexo node.