### PR TITLE
netsync, blockchain: Don't require utxo cache for utreexo nodes

### DIFF
--- a/netsync/blocklogger.go
+++ b/netsync/blocklogger.go
@@ -68,7 +68,13 @@ func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block, chain *blockc
 	if b.receivedLogTx == 1 {
 		txStr = "transaction"
 	}
-	cacheSizeStr := fmt.Sprintf("~%d MiB", chain.CachedStateSize()/1024/1024)
+
+	// No cacheSizeStr exists for utreexo nodes.  Only try to get state for non-utreexo
+	// nodes.
+	cacheSizeStr := "N/A"
+	if !chain.IsUtreexoViewActive() {
+		cacheSizeStr = fmt.Sprintf("~%d MiB", chain.CachedStateSize()/1024/1024)
+	}
 	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s, %s cache)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
 		txStr, block.Height(), block.MsgBlock().Header.Timestamp, cacheSizeStr)


### PR DESCRIPTION
Utreexo nodes are able to replace the entire utxo set with the
utreexo accumulator state.  Previously, the utxo cache was required even
for utreexo nodes as it wasn't implemented.  This commit fixes all the
parts of the code so that a utreexo node doesn't keep a utxo cache.