### PR TITLE
btcd: Change GC percent to 30

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -350,7 +350,7 @@ func main() {
 	// limits the garbage collector from excessively overallocating during
 	// bursts.  This value was arrived at with the help of profiling live
 	// usage.
-	debug.SetGCPercent(10)
+	debug.SetGCPercent(30)
 
 	// Up some limits.
 	if err := limits.SetLimits(); err != nil {


### PR DESCRIPTION
GC percent was previously set at 10 percent.  This repo has had many
PRs that reduced memory allocation.  It's now ok to increase the GC
percentage and not use too much system memory.