### PR TITLE
wire/msgtx: Make TxHash() allocate less memory

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -35,8 +35,8 @@ func DoubleHashH(b []byte) Hash {
 	return Hash(sha256.Sum256(first[:]))
 }
 
-// DoubleHashBRaw calculates hash(hash(h)) and returns the resulting bytes.
-func DoubleHashBRaw(h hash.Hash) []byte {
+// DoubleHashRaw calculates hash(hash(h)) and returns the resulting bytes.
+func DoubleHashRaw(h hash.Hash) []byte {
 	first := h.Sum(nil)
 	h.Reset()
 	h.Write(first)

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -459,7 +459,7 @@ func calcWitnessSignatureHashRaw(scriptSig []byte, sigHashes *TxSigHashes,
 	binary.LittleEndian.PutUint32(bHashType[:], uint32(hashType))
 	sigHash.Write(bHashType[:])
 
-	return chainhash.DoubleHashBRaw(sigHash), nil
+	return chainhash.DoubleHashRaw(sigHash), nil
 }
 
 // CalcWitnessSigHash computes the sighash digest for the specified input of
@@ -626,7 +626,7 @@ func calcSignatureHash(sigScript []byte, hashType SigHashType, tx *wire.MsgTx, i
 	var bHashType [4]byte
 	binary.LittleEndian.PutUint32(bHashType[:], uint32(hashType))
 	sigHash.Write(bHashType[:])
-	return chainhash.DoubleHashBRaw(sigHash)
+	return chainhash.DoubleHashRaw(sigHash)
 }
 
 // asSmallInt returns the passed opcode, which must be true according to

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"strconv"
@@ -334,9 +335,10 @@ func (msg *MsgTx) TxHash() chainhash.Hash {
 	// Ignore the error returns since the only way the encode could fail
 	// is being out of memory or due to nil pointers, both of which would
 	// cause a run-time panic.
-	buf := bytes.NewBuffer(make([]byte, 0, msg.SerializeSizeStripped()))
-	_ = msg.SerializeNoWitness(buf)
-	return chainhash.DoubleHashH(buf.Bytes())
+	txHash := sha256.New()
+	_ = msg.SerializeNoWitness(txHash)
+	bytes := chainhash.DoubleHashRaw(txHash)
+	return *((*[32]byte)(bytes))
 }
 
 // WitnessHash generates the hash of the transaction serialized according to


### PR DESCRIPTION
TxHash() would allocate bytes for the tx, then allocate more in
chainhash.DoubleHashH, and then allocate again when doing the double
hash.  TxHash() is changed to allocate only once.