### PR TITLE
rpcserver: Modify gettxtotals command

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -516,6 +516,8 @@ type GetTxTotalsResult struct {
 	TotalTxBytesSent    uint64 `json:"totaltxbytessent"`
 	TotalProofBytesRecv uint64 `json:"totalproofbytesrecv"`
 	TotalProofBytesSent uint64 `json:"totalproofbytessent"`
+	TotalAccBytesRecv   uint64 `json:"totalaccbytesrecv"`
+	TotalAccBytesSent   uint64 `json:"totalaccbytessent"`
 	TimeMillis          int64  `json:"timemillis"`
 }
 

--- a/rpcadapters.go
+++ b/rpcadapters.go
@@ -170,7 +170,7 @@ func (cm *rpcConnManager) NetTotals() (uint64, uint64) {
 //
 // This function is safe for concurrent access and is part of the
 // rpcserverConnManager interface implementation.
-func (cm *rpcConnManager) TxTotals() (uint64, uint64, uint64, uint64) {
+func (cm *rpcConnManager) TxTotals() (uint64, uint64, uint64, uint64, uint64, uint64) {
 	return cm.server.TxTotals()
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2396,12 +2396,14 @@ func handleGetNetTotals(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 
 // handleGetTxTotals implements the gettxtotals command.
 func handleGetTxTotals(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	txBytesRecv, txBytesSent, proofBytesRecv, proofBytesSent := s.cfg.ConnMgr.TxTotals()
+	txBytesRecv, txBytesSent, proofBytesRecv, proofBytesSent, accBytesRecv, accBytesSent := s.cfg.ConnMgr.TxTotals()
 	reply := &btcjson.GetTxTotalsResult{
 		TotalTxBytesRecv:    txBytesRecv,
 		TotalTxBytesSent:    txBytesSent,
 		TotalProofBytesRecv: proofBytesRecv,
 		TotalProofBytesSent: proofBytesSent,
+		TotalAccBytesRecv:   accBytesRecv,
+		TotalAccBytesSent:   accBytesSent,
 		TimeMillis:          time.Now().UTC().UnixNano() / int64(time.Millisecond),
 	}
 	return reply, nil
@@ -4547,7 +4549,7 @@ type rpcserverConnManager interface {
 
 	// TxTotals returns the sum of all bytes received and sent across the
 	// network for all peers for tx messages.
-	TxTotals() (uint64, uint64, uint64, uint64)
+	TxTotals() (uint64, uint64, uint64, uint64, uint64, uint64)
 
 	// ConnectedPeers returns an array consisting of all connected peers.
 	ConnectedPeers() []rpcserverPeer

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -462,8 +462,10 @@ var helpDescsEnUS = map[string]string{
 	// GetTxTotalsResult help.
 	"gettxtotalsresult-totaltxbytesrecv":    "Total tx bytes received",
 	"gettxtotalsresult-totaltxbytessent":    "Total tx bytes sent",
-	"gettxtotalsresult-totalproofbytesrecv": "Total proof bytes received",
-	"gettxtotalsresult-totalproofbytessent": "Total proof bytes sent",
+	"gettxtotalsresult-totalproofbytesrecv": "Total utxo data bytes received",
+	"gettxtotalsresult-totalproofbytessent": "Total utxo data bytes sent",
+	"gettxtotalsresult-totalaccbytesrecv":   "Total accumulator proof bytes received",
+	"gettxtotalsresult-totalaccbytessent":   "Total accumulator proof bytes sent",
 	"gettxtotalsresult-timemillis":          "Number of milliseconds since 1 Jan 1970 GMT",
 
 	// GetNodeAddressesResult help.

--- a/wire/udata.go
+++ b/wire/udata.go
@@ -178,6 +178,27 @@ func (ud *UData) Deserialize(r io.Reader) error {
 //
 // -----------------------------------------------------------------------------
 
+// SerializeAccSizeCompact returns the number of bytes it would take to serialize
+// the accumulator with the compact accumulator serialization format.
+func (ud *UData) SerializeAccSizeCompact() int {
+	return BatchProofSerializeSize(&ud.AccProof)
+}
+
+// SerializeUxtoDataSizeCompact returns the number of bytes it would take to serialize
+// the utxo data and the ttl data with the compact serialization format.
+func (ud *UData) SerializeUxtoDataSizeCompact(isForTx bool) int {
+	// Size of all the leafData.
+	var ldSize int
+	for _, l := range ud.LeafDatas {
+		ldSize += l.SerializeSizeCompact(isForTx)
+	}
+
+	// Size of all the time to live values.
+	txoTTLSize := len(ud.TxoTTLs) * 4
+
+	return ldSize + txoTTLSize
+}
+
 // SerializeSizeCompact returns the number of bytes it would take to serialize the
 // UData using the compact UData serialization format.
 func (ud *UData) SerializeSizeCompact(isForTx bool) int {

--- a/wire/udata_test.go
+++ b/wire/udata_test.go
@@ -287,6 +287,14 @@ func TestUDataSerializeSize(t *testing.T) {
 				"expect %d, got %d", test.name,
 				test.sizeCompactTx, gotSize)
 		}
+
+		// Test that SerializeUxtoDataSizeCompact and SerializeUxtoDataSizeCompact
+		// sums up to the entire thing.
+		totals := test.ud.SerializeUxtoDataSizeCompact(true) + test.ud.SerializeAccSizeCompact()
+		if totals != test.ud.SerializeSizeCompact(true) {
+			t.Errorf("%s: expected %d for but got %d as the sum of utxodata and accumulator data",
+				test.name, test.ud.SerializeAccSizeCompact(), totals)
+		}
 	}
 }
 


### PR DESCRIPTION
gettxtotals now adds total sent and received for the utxo data.  Accumulator
data and the utxo data is differentiated so the caller can see how many
bytes have gone into the accumulator proof vs the utxo data.